### PR TITLE
Emit node selected on last unselect

### DIFF
--- a/nodz_demo.py
+++ b/nodz_demo.py
@@ -1,5 +1,11 @@
-from Qt import QtCore
+from Qt import QtCore, QtWidgets
 import nodz_main
+
+try:
+    app = QtWidgets.QApplication([])
+except:
+    # I guess we're running somewhere that already has a QApp created
+    app = None
 
 nodz = nodz_main.Nodz(None)
 # nodz.loadConfig(filePath='')
@@ -91,13 +97,13 @@ nodz.createAttribute(node=nodeA, name='Aattr1', index=-1, preset='attr_preset_1'
                      plug=True, socket=False, dataType=str)
 
 nodz.createAttribute(node=nodeA, name='Aattr2', index=-1, preset='attr_preset_1',
-                     plug=True, socket=False, dataType=int)
+                     plug=False, socket=False, dataType=int)
 
 nodz.createAttribute(node=nodeA, name='Aattr3', index=-1, preset='attr_preset_2',
-                     plug=True, socket=False, dataType=int)
+                     plug=True, socket=True, dataType=int)
 
 nodz.createAttribute(node=nodeA, name='Aattr4', index=-1, preset='attr_preset_2',
-                     plug=True, socket=False, dataType=str)
+                     plug=True, socket=True, dataType=str)
 
 
 
@@ -172,4 +178,6 @@ nodz.loadGraph(filePath='Enter your path')
 
 
 
-
+if app:
+    # command line stand alone test... run our own event loop
+    app.exec_()

--- a/nodz_main.py
+++ b/nodz_main.py
@@ -7,7 +7,7 @@ import nodz_utils as utils
 
 
 
-defautConfigPath = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'default_config.json')
+defaultConfigPath = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'default_config.json')
 config = None
 
 
@@ -393,7 +393,7 @@ class Nodz(QtWidgets.QGraphicsView):
         # end if
         bbw = bbx_max - bbx_min
         bbh = bby_max - bby_min
-        return QtCore.QRect(bbx_min, bby_min, bbw, bbh)
+        return QtCore.QRectF(QtCore.QRect(bbx_min, bby_min, bbw, bbh))
 
     def _deleteSelectedNodes(self):
         """
@@ -426,7 +426,7 @@ class Nodz(QtWidgets.QGraphicsView):
     # API
     ##################################################################
 
-    def loadConfig(self, filePath=defautConfigPath):
+    def loadConfig(self, filePath=defaultConfigPath):
         """
         Set a specific configuration for this instance of Nodz.
 
@@ -435,7 +435,7 @@ class Nodz(QtWidgets.QGraphicsView):
                          use.
 
         """
-        data = utils._loadConfig(filePath=defautConfigPath)
+        data = utils._loadConfig(filePath)
 
         global config
         config = data
@@ -795,9 +795,9 @@ class Nodz(QtWidgets.QGraphicsView):
 
 
         # Save data.
-        if os.path.exists(filePath):
+        try:
             utils._saveData(filePath=filePath, data=data)
-        else:
+        except:
             print 'Invalid path : {0}'.format(filePath)
             print 'Save aborted !'
             return False

--- a/nodz_main.py
+++ b/nodz_main.py
@@ -414,8 +414,8 @@ class Nodz(QtWidgets.QGraphicsView):
             for node in self.scene().selectedItems():
                 selected_nodes.append(node.name)
 
-            # Emit signal.
-            self.signal_NodeSelected.emit(selected_nodes)
+        # Emit signal.
+        self.signal_NodeSelected.emit(selected_nodes)
 
 
     ##################################################################

--- a/nodz_main.py
+++ b/nodz_main.py
@@ -873,27 +873,31 @@ class Nodz(QtWidgets.QGraphicsView):
             targetNode = target.split('.')[0]
             targetAttr = target.split('.')[1]
 
-            plug = self.scene().nodes[sourceNode].plugs[sourceAttr]
-            socket = self.scene().nodes[targetNode].sockets[targetAttr]
-
-            connection = ConnectionItem(plug.center(), socket.center(), plug, socket)
-
-            connection.plugNode = plug.parentItem().name
-            connection.plugAttr = plug.attribute
-            connection.socketNode = socket.parentItem().name
-            connection.socketAttr = socket.attribute
-
-            plug.connect(socket, connection)
-            socket.connect(plug, connection)
-
-            connection.updatePath()
-
-            self.scene().addItem(connection)
+            self.createConnection(sourceNode, sourceAttr,
+                                  targetNode, targetAttr)
 
         self.scene().update()
 
         # Emit signal.
         self.signal_GraphLoaded.emit()
+
+    def createConnection(self, sourceNode, sourceAttr, targetNode, targetAttr):
+        plug = self.scene().nodes[sourceNode].plugs[sourceAttr]
+        socket = self.scene().nodes[targetNode].sockets[targetAttr]
+
+        connection = ConnectionItem(plug.center(), socket.center(), plug, socket)
+
+        connection.plugNode = plug.parentItem().name
+        connection.plugAttr = plug.attribute
+        connection.socketNode = socket.parentItem().name
+        connection.socketAttr = socket.attribute
+
+        plug.connect(socket, connection)
+        socket.connect(plug, connection)
+
+        connection.updatePath()
+
+        self.scene().addItem(connection)
 
     def evaluateGraph(self):
         """

--- a/nodz_utils.py
+++ b/nodz_utils.py
@@ -84,6 +84,7 @@ def _createPointerBoundingBox(pointerPos, bbSize):
 
     size = QtCore.QSize(bbSize, bbSize)
     bb = QtCore.QRect(mbbPos, size)
+    bb = QtCore.QRectF(bb)
 
     return bb
 


### PR DESCRIPTION
when selecting and unselecting nodes in the graph all changes are announced via the NodeSelected signal *except* when the state transitions to no selections.

it appears this was a simple indentation bug in the _returnSelection method