### PR TITLE
Fix node deletion not removing all connections if multiple connections

### DIFF
--- a/nodz_main.py
+++ b/nodz_main.py
@@ -1283,13 +1283,13 @@ class NodeItem(QtWidgets.QGraphicsItem):
 
         # Remove all sockets connections.
         for socket in self.sockets.values():
-            for connection in socket.connections:
-                connection._remove()
+            while len(socket.connections)>0:
+                socket.connections[0]._remove()
 
         # Remove all plugs connections.
         for plug in self.plugs.values():
-            for connection in plug.connections:
-                connection._remove()
+            while len(plug.connections)>0:
+                plug.connections[0]._remove()
 
         # Remove node.
         scene = self.scene()


### PR DESCRIPTION
There is a bug when deleting a socket with multiple connections on it, it won't iterate correctly on all values because the connection is deleted within the for ... in ... loop.

You can witness the bug by typing the following lines in the sample, it will trow an exception in the deleteNode(nodeB) because the deleteNode(nodeA) did not delete the second connection:

######################################################################
# Reveal node's connection deletion bug
######################################################################
nodeA = nodz.createNode(name='nodeA', preset='node_preset_1', position=None)
nodz.createAttribute(node=nodeA, name='Aattr1', index=-1, preset='attr_preset_1',
                      plug=True, socket=False, dataType=int)

nodeB = nodz.createNode(name='nodeB', preset='node_preset_1', position=None)
nodz.createAttribute(node=nodeB, name='Aattr1', index=-1, preset='attr_preset_1',
                      plug=False, socket=True, dataType=int)
nodz.createAttribute(node=nodeB, name='Aattr2', index=-1, preset='attr_preset_1',
                      plug=False, socket=True, dataType=int)

nodz.createConnection('nodeA', 'Aattr1', 'nodeB', 'Aattr1')
nodz.createConnection('nodeA', 'Aattr1', 'nodeB', 'Aattr2')


nodz.deleteNode(node=nodeA)
nodz.deleteNode(node=nodeB)