### PR TITLE
py3 compatibility

### DIFF
--- a/nodz_demo.py
+++ b/nodz_demo.py
@@ -20,63 +20,63 @@ nodz.show()
 # Nodes
 @QtCore.Slot(str)
 def on_nodeCreated(nodeName):
-    print 'node created : ', nodeName
+    print('node created : ', nodeName)
 
 @QtCore.Slot(str)
 def on_nodeDeleted(nodeName):
-    print 'node deleted : ', nodeName
+    print('node deleted : ', nodeName)
 
 @QtCore.Slot(str, str)
 def on_nodeEdited(nodeName, newName):
-    print 'node edited : {0}, new name : {1}'.format(nodeName, newName)
+    print('node edited : {0}, new name : {1}'.format(nodeName, newName))
 
 @QtCore.Slot(str)
 def on_nodeSelected(nodesName):
-    print 'node selected : ', nodesName
+    print('node selected : ', nodesName)
 
 # Attrs
 @QtCore.Slot(str, int)
 def on_attrCreated(nodeName, attrId):
-    print 'attr created : {0} at index : {1}'.format(nodeName, attrId)
+    print('attr created : {0} at index : {1}'.format(nodeName, attrId))
 
 @QtCore.Slot(str, int)
 def on_attrDeleted(nodeName, attrId):
-    print 'attr Deleted : {0} at old index : {1}'.format(nodeName, attrId)
+    print('attr Deleted : {0} at old index : {1}'.format(nodeName, attrId))
 
 @QtCore.Slot(str, int, int)
 def on_attrEdited(nodeName, oldId, newId):
-    print 'attr Edited : {0} at old index : {1}, new index : {2}'.format(nodeName, oldId, newId)
+    print('attr Edited : {0} at old index : {1}, new index : {2}'.format(nodeName, oldId, newId))
 
 # Connections
 @QtCore.Slot(str, str, str, str)
 def on_connected(srcNodeName, srcPlugName, destNodeName, dstSocketName):
-    print 'connected src: "{0}" at "{1}" to dst: "{2}" at "{3}"'.format(srcNodeName, srcPlugName, destNodeName, dstSocketName)
+    print('connected src: "{0}" at "{1}" to dst: "{2}" at "{3}"'.format(srcNodeName, srcPlugName, destNodeName, dstSocketName))
 
 @QtCore.Slot(str, str, str, str)
 def on_disconnected(srcNodeName, srcPlugName, destNodeName, dstSocketName):
-    print 'disconnected src: "{0}" at "{1}" from dst: "{2}" at "{3}"'.format(srcNodeName, srcPlugName, destNodeName, dstSocketName)
+    print('disconnected src: "{0}" at "{1}" from dst: "{2}" at "{3}"'.format(srcNodeName, srcPlugName, destNodeName, dstSocketName))
 
 # Graph
 @QtCore.Slot()
 def on_graphSaved():
-    print 'graph saved !'
+    print('graph saved !')
 
 @QtCore.Slot()
 def on_graphLoaded():
-    print 'graph loaded !'
+    print('graph loaded !')
 
 @QtCore.Slot()
 def on_graphCleared():
-    print 'graph cleared !'
+    print('graph cleared !')
 
 @QtCore.Slot()
 def on_graphEvaluated():
-    print 'graph evaluated !'
+    print('graph evaluated !')
 
 # Other
 @QtCore.Slot(object)
 def on_keyPressed(key):
-    print 'key pressed : ', key
+    print('key pressed : ', key)
 
 nodz.signal_NodeCreated.connect(on_nodeCreated)
 nodz.signal_NodeDeleted.connect(on_nodeDeleted)
@@ -185,7 +185,7 @@ nodz.deleteNode(node=nodeC)
 
 
 # Graph
-print nodz.evaluateGraph()
+print(nodz.evaluateGraph())
 
 nodz.saveGraph(filePath='Enter your path')
 

--- a/nodz_main.py
+++ b/nodz_main.py
@@ -1,6 +1,7 @@
 import os
 import re
 import json
+import six
 
 from Qt import QtGui, QtCore, QtWidgets
 import nodz_utils as utils
@@ -498,8 +499,8 @@ class Nodz(QtWidgets.QGraphicsView):
         """
         # Check for name clashes
         if name in self.scene().nodes.keys():
-            print 'A node with the same name already exists : {0}'.format(name)
-            print 'Node creation aborted !'
+            print('A node with the same name already exists : {0}'.format(name))
+            print('Node creation aborted !')
             return
         else:
             nodeItem = NodeItem(name=name, alternate=alternate, preset=preset,
@@ -530,8 +531,8 @@ class Nodz(QtWidgets.QGraphicsView):
 
         """
         if not node in self.scene().nodes.values():
-            print 'Node object does not exist !'
-            print 'Node deletion aborted !'
+            print('Node object does not exist !')
+            print('Node deletion aborted !')
             return
 
         if node in self.scene().nodes.values():
@@ -553,8 +554,8 @@ class Nodz(QtWidgets.QGraphicsView):
 
         """
         if not node in self.scene().nodes.values():
-            print 'Node object does not exist !'
-            print 'Node edition aborted !'
+            print('Node object does not exist !')
+            print('Node edition aborted !')
             return
 
         oldName = node.name
@@ -562,8 +563,8 @@ class Nodz(QtWidgets.QGraphicsView):
         if newName != None:
             # Check for name clashes
             if newName in self.scene().nodes.keys():
-                print 'A node with the same name already exists : {0}'.format(newName)
-                print 'Node edition aborted !'
+                print('A node with the same name already exists : {0}'.format(newName))
+                print('Node edition aborted !')
                 return
             else:
                 node.name = newName
@@ -622,13 +623,13 @@ class Nodz(QtWidgets.QGraphicsView):
 
         """
         if not node in self.scene().nodes.values():
-            print 'Node object does not exist !'
-            print 'Attribute creation aborted !'
+            print('Node object does not exist !')
+            print('Attribute creation aborted !')
             return
 
         if name in node.attrs:
-            print 'An attribute with the same name already exists : {0}'.format(name)
-            print 'Attribute creation aborted !'
+            print('An attribute with the same name already exists : {0}'.format(name))
+            print('Attribute creation aborted !')
             return
 
         node._createAttribute(name=name, index=index, preset=preset, plug=plug, socket=socket, dataType=dataType)
@@ -648,8 +649,8 @@ class Nodz(QtWidgets.QGraphicsView):
 
         """
         if not node in self.scene().nodes.values():
-            print 'Node object does not exist !'
-            print 'Attribute deletion aborted !'
+            print('Node object does not exist !')
+            print('Attribute deletion aborted !')
             return
 
         node._deleteAttribute(index)
@@ -675,14 +676,14 @@ class Nodz(QtWidgets.QGraphicsView):
 
         """
         if not node in self.scene().nodes.values():
-            print 'Node object does not exist !'
-            print 'Attribute creation aborted !'
+            print('Node object does not exist !')
+            print('Attribute creation aborted !')
             return
 
         if newName != None:
             if newName in node.attrs:
-                print 'An attribute with the same name already exists : {0}'.format(newName)
-                print 'Attribute edition aborted !'
+                print('An attribute with the same name already exists : {0}'.format(newName))
+                print('Attribute edition aborted !')
                 return
             else:
                 oldName = node.attrs[index]
@@ -798,8 +799,8 @@ class Nodz(QtWidgets.QGraphicsView):
         try:
             utils._saveData(filePath=filePath, data=data)
         except:
-            print 'Invalid path : {0}'.format(filePath)
-            print 'Save aborted !'
+            print('Invalid path : {0}'.format(filePath))
+            print('Save aborted !')
             return False
 
         # Emit signal.
@@ -818,8 +819,8 @@ class Nodz(QtWidgets.QGraphicsView):
         if os.path.exists(filePath):
             data = utils._loadData(filePath=filePath)
         else:
-            print 'Invalid path : {0}'.format(filePath)
-            print 'Load aborted !'
+            print('Invalid path : {0}'.format(filePath))
+            print('Load aborted !')
             return False
 
         # Apply nodes data.
@@ -849,7 +850,7 @@ class Nodz(QtWidgets.QGraphicsView):
                 dataType = attrData['dataType']
 
                 # un-serialize data type if needed
-                if (isinstance(dataType, unicode) and dataType.find('<') == 0):
+                if (isinstance(dataType, six.text_type) and dataType.find('<') == 0):
                     dataType = eval(str(dataType.split('\'')[1]))
 
                 self.createAttribute(node=node,
@@ -1190,8 +1191,8 @@ class NodeItem(QtWidgets.QGraphicsItem):
 
         """
         if name in self.attrs:
-            print 'An attribute with the same name already exists on this node : {0}'.format(name)
-            print 'Attribute creation aborted !'
+            print('An attribute with the same name already exists on this node : {0}'.format(name))
+            print('Attribute creation aborted !')
             return
 
         self.attrPreset = preset

--- a/nodz_utils.py
+++ b/nodz_utils.py
@@ -39,9 +39,9 @@ def _convertDataToColor(data=None, alternate=False, av=20):
 
     # wrong
     else:
-        print 'Color from configuration is not recognized : ', data
-        print 'Can only be [R, G, B] or [R, G, B, A]'
-        print 'Using default color !'
+        print('Color from configuration is not recognized : ', data)
+        print('Can only be [R, G, B] or [R, G, B, A]')
+        print('Using default color !')
         color = QtGui.QColor(120, 120, 120)
         if alternate:
             color = QtGui.QColor(120-av, 120-av, 120-av)
@@ -150,7 +150,7 @@ def _saveData(filePath, data):
                        ensure_ascii=False))
     f.close()
 
-    print "Data successfully saved !"
+    print("Data successfully saved !")
 
 def _loadData(filePath):
     """
@@ -165,6 +165,6 @@ def _loadData(filePath):
 
     json_file.close()
 
-    print "Data successfully loaded !"
+    print("Data successfully loaded !")
     return j_data
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Qt.py
+six


### PR DESCRIPTION
A couple of small tweaks that allow the demo to run under python 3, tested with python 3.6 on CentOS
- Add brackets to print statements.
- Swap 'unicode' with 'six.text_type'

I also created a requirements.txt file and added both six and Qt.py to it.