### PR TITLE
Added a signal_NodeMoved to keep track of the nodes's positions out of the Nodz editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ signal_NodeCreated(nodeName)
 signal_NodeDeleted([nodeNames])
 signal_NodeEdited(oldName, newName)
 signal_NodeSelected([nodeNames])
+signal_NodeMoved(nodeName, nodePos)
 ```
 Attributes
 ```Python

--- a/nodz_demo.py
+++ b/nodz_demo.py
@@ -34,6 +34,10 @@ def on_nodeEdited(nodeName, newName):
 def on_nodeSelected(nodesName):
     print 'node selected : ', nodesName
 
+@QtCore.Slot(str, object)
+def on_nodeMoved(nodeName, nodePos):
+    print 'node {0} moved to {1}'.format(nodeName, nodePos)
+
 # Attrs
 @QtCore.Slot(str, int)
 def on_attrCreated(nodeName, attrId):
@@ -82,6 +86,7 @@ nodz.signal_NodeCreated.connect(on_nodeCreated)
 nodz.signal_NodeDeleted.connect(on_nodeDeleted)
 nodz.signal_NodeEdited.connect(on_nodeEdited)
 nodz.signal_NodeSelected.connect(on_nodeSelected)
+nodz.signal_NodeMoved.connect(on_nodeMoved)
 
 nodz.signal_AttrCreated.connect(on_attrCreated)
 nodz.signal_AttrDeleted.connect(on_attrDeleted)

--- a/nodz_main.py
+++ b/nodz_main.py
@@ -24,6 +24,7 @@ class Nodz(QtWidgets.QGraphicsView):
     signal_NodeDeleted = QtCore.Signal(object)
     signal_NodeEdited = QtCore.Signal(object, object)
     signal_NodeSelected = QtCore.Signal(object)
+    signal_NodeMoved = QtCore.Signal(str, object)
 
     signal_AttrCreated = QtCore.Signal(object, object)
     signal_AttrDeleted = QtCore.Signal(object, object)
@@ -462,6 +463,8 @@ class Nodz(QtWidgets.QGraphicsView):
         sceneHeight = config['scene_height']
         scene.setSceneRect(0, 0, sceneWidth, sceneHeight)
         self.setScene(scene)
+        # Connect scene node moved signal
+        scene.signal_NodeMoved.connect(self.signal_NodeMoved)
 
         # Tablet zoom.
         self.previousMouseOffset = 0
@@ -960,6 +963,7 @@ class NodeScene(QtWidgets.QGraphicsScene):
     The scene displaying all the nodes.
 
     """
+    signal_NodeMoved = QtCore.Signal(str, object)
 
     def __init__(self, parent):
         """
@@ -1442,6 +1446,9 @@ class NodeItem(QtWidgets.QGraphicsItem):
             else:
                 self.scene().updateScene()
                 super(NodeItem, self).mouseMoveEvent(event)
+            # Emit signal.
+            self.scene().signal_NodeMoved.emit(self.name, self.pos())
+
 
     def hoverLeaveEvent(self, event):
         """

--- a/nodz_main.py
+++ b/nodz_main.py
@@ -1446,9 +1446,15 @@ class NodeItem(QtWidgets.QGraphicsItem):
             else:
                 self.scene().updateScene()
                 super(NodeItem, self).mouseMoveEvent(event)
-            # Emit signal.
-            self.scene().signal_NodeMoved.emit(self.name, self.pos())
 
+    def mouseReleaseEvent(self, event):
+        """
+        .
+
+        """
+        # Emit node moved signal.
+        self.scene().signal_NodeMoved.emit(self.name, self.pos())
+        super(NodeItem, self).mouseReleaseEvent(event)
 
     def hoverLeaveEvent(self, event):
         """


### PR DESCRIPTION
When using Nodz for displaying a graph that is saved elsewhere, it may be useful to keep tracks of the nodes's position to be able to restore them properly when reloading the graph.
This simple signal allows to do that easily.