### PR TITLE
Fixed attribute text not correctly displayed when it has several lines

### DIFF
--- a/nodz_main.py
+++ b/nodz_main.py
@@ -1393,14 +1393,11 @@ class NodeItem(QtWidgets.QGraphicsItem):
                         # Set non-connectable attributes color.
                         painter.setPen(utils._convertDataToColor(config['non_connectable_color']))
 
-
-
-            painter.drawText(QtCore.QRect(0.5 + 10,
-                                          self.baseHeight-self.radius+(self.attrHeight/4)+offset,
-                                          self.baseWidth - 20,
-                                          self.attrHeight),
-                                            0.5, name)
-
+            textRect = QtCore.QRect(rect.left() + self.radius,
+                                     rect.top(),
+                                     rect.width() - 2*self.radius,
+                                     rect.height())
+            painter.drawText(textRect, QtCore.Qt.AlignVCenter, name)
 
             offset += self.attrHeight
 


### PR DESCRIPTION
Fixed attribute text not correctly displayed when it has several lines even if the "node_attr_height" config value is set with enough room to display it.

To demonstrate the bug, add the following node in the nodz_demo.py:
```
textToDisplay='This is my attribute.\nIt has several lines,and I\nchanged the node_attr_height\nto a bigger value in the presets\nto display it all.\nBut my concern is that it\'s not\ncentered on the box and so not\ncompletelly displayed even if\nthere is enough room for\neverything.'
nodzObject = nodz.createNode(name='Note', preset='node_preset_1', position=None)
nodz.createAttribute(node=nodzObject, name=textToDisplay, index=-1, plug=False, socket=False, dataType=str)
nodz.createAttribute(node=nodzObject, name='Note Attribute 2.', index=-1, plug=False, socket=False, dataType=str)
```

And change the "node_attr_height" setting to 170 in the default_config.json

This commit fix the issue by centering the attribute text vertically in its rect.

Here is the bug:
![](https://i.imgur.com/Tt7FcV4.png)

And here is the result with the same parameters once fixed:
![](https://i.imgur.com/3H7utEp.png)



