### PR TITLE
Including backspace hotkey in addition to delete to support macbooks

### DIFF
--- a/nodz_main.py
+++ b/nodz_main.py
@@ -291,7 +291,7 @@ class Nodz(QtWidgets.QGraphicsView):
         if event.key() not in self.pressedKeys:
             self.pressedKeys.append(event.key())
 
-        if event.key() == QtCore.Qt.Key_Delete:
+        if event.key() in (QtCore.Qt.Key_Delete, QtCore.Qt.Key_Backspace):
             self._deleteSelectedNodes()
 
         if event.key() == QtCore.Qt.Key_F:


### PR DESCRIPTION
Adding backspace hotkey so that it deletes as well as the delete key. Macbooks don't have a delete key, only a backspace key.