### PR TITLE
Fix split for node/attributes in loadGraph()

### DIFF
--- a/nodz_main.py
+++ b/nodz_main.py
@@ -880,12 +880,12 @@ class Nodz(QtWidgets.QGraphicsView):
 
         for connection in connectionsData:
             source = connection[0]
-            sourceNode = source.split('.')[0]
-            sourceAttr = source.split('.')[1]
+            sourceNode = source.rpartition('.')[0]
+            sourceAttr = source.rpartition('.')[-1]
 
             target = connection[1]
-            targetNode = target.split('.')[0]
-            targetAttr = target.split('.')[1]
+            targetNode = target.rpartition('.')[0]
+            targetAttr = target.rpartition('.')[-1]
 
             self.createConnection(sourceNode, sourceAttr,
                                   targetNode, targetAttr)


### PR DESCRIPTION
If we have a node in the JSON like "node.color.R", there is an error.
I added a rpartition instead of a split in order to have the last element for the attribute and the first element for the node : "node.color" for the name dans "R" for the attribute.